### PR TITLE
go get -u github.com/banaio/blondie/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/myles-mcdonnell/blondie)](https://goreportcard.com/report/github.com/myles-mcdonnell/blondie)
 
 
+## install
+```sh
+go get -u github.com/banaio/blondie/...
+blondie -help
+Usage of blondie:
+  -exit-code-on-connect int
+    	Exit code when connection is made
+  -exit-code-on-fail int
+    	Exit code when connection is not made (default 1)
+  -poll-interval int
+    	poll interval in milliseconds (default 250)
+  -quiet-mode
+    	suppress all output
+  -targets string
+    	comma separated protocol:address:port:timeoutSeconds:[path]:[successcode], e.g. [tcp|http|https]:localhost:8080:60:[path]:[success_error_code] timeout is optional in which case the global timeout is used, final two arguments for htyp only
+```
+
 A command that polls one or more TCP sockets/HTTP endpoints until a connection is made or the timeout is hit.  Useful if you need to wait for a server or group of servers to start before doing something else.
 
 Why call it Blondie? This is the best I could come up with in the 5 seconds I allowed for naming it [https://www.youtube.com/watch?v=uWhkbDMISl8](https://www.youtube.com/watch?v=uWhkbDMISl8)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## install
 ```sh
-go get -u github.com/banaio/blondie/...
+go get -u github.com/myles-mcdonnell/blondie/...
 blondie -help
 Usage of blondie:
   -exit-code-on-connect int

--- a/cmd/blondie/main.go
+++ b/cmd/blondie/main.go
@@ -11,7 +11,6 @@ import (
 )
 
 func main() {
-
 	targets := flag.String("targets", "", "comma separated protocol:address:port:timeoutSeconds:[path]:[successcode], e.g. [tcp|http|https]:localhost:8080:60:[path]:[success_error_code] timeout is optional in which case the global timeout is used, final two arguments for htyp only")
 	pollinterval := flag.Int("poll-interval", 250, "poll interval in milliseconds")
 	exitCodeOnConnectOk := flag.Int("exit-code-on-connect", 0, "Exit code when connection is made")
@@ -49,7 +48,7 @@ func main() {
 		var err error
 		var port int
 		if port, err = strconv.Atoi(protoAddrPortAndTimeout[2]); err != nil {
-			fmt.Println("Unable to parse port %s", protoAddrPortAndTimeout[2])
+			fmt.Printf("Unable to parse port %s", protoAddrPortAndTimeout[2])
 			os.Exit(*exitCodeOnConnectFail)
 		}
 
@@ -74,7 +73,7 @@ func main() {
 			if len(protoAddrPortAndTimeout) > 5 {
 				successcode, err := strconv.Atoi(protoAddrPortAndTimeout[5])
 				if err != nil {
-					fmt.Println("Can not parse success code to int %s", protoAddrPortAndTimeout[5])
+					fmt.Printf("Can not parse success code to int %s", protoAddrPortAndTimeout[5])
 					os.Exit(*exitCodeOnConnectFail)
 				} else {
 					successcodes = []int{successcode}
@@ -85,7 +84,7 @@ func main() {
 			depChecks[index] = blondie.NewHttpCheck(host, port, timeout, path, successcodes)
 			break
 		default:
-			fmt.Println("Unsupported protocol %s", protocol)
+			fmt.Printf("Unsupported protocol %s", protocol)
 			os.Exit(*exitCodeOnConnectFail)
 		}
 

--- a/cmd/blondie/main.go
+++ b/cmd/blondie/main.go
@@ -1,4 +1,4 @@
-package blondie
+package main
 
 import (
 	"flag"

--- a/cmd/blondie/main.go
+++ b/cmd/blondie/main.go
@@ -1,4 +1,4 @@
-package main
+package blondie
 
 import (
 	"flag"


### PR DESCRIPTION
```sh
root@b6214668e028:~# go get -u github.com/banaio/blondie/...
root@b6214668e028:~# find / -name 'blondie'
/go/src/github.com/banaio/blondie
/go/src/github.com/banaio/blondie/cmd/blondie
/go/src/github.com/myles-mcdonnell/blondie
/go/bin/blondie
root@b6214668e028:~# blondie -help
Usage of blondie:
  -exit-code-on-connect int
    	Exit code when connection is made
  -exit-code-on-fail int
    	Exit code when connection is not made (default 1)
  -poll-interval int
    	poll interval in milliseconds (default 250)
  -quiet-mode
    	suppress all output
  -targets string
    	comma separated protocol:address:port:timeoutSeconds:[path]:[successcode], e.g. [tcp|http|https]:localhost:8080:60:[path]:[success_error_code] timeout is optional in which case the global timeout is used, final two arguments for htyp only

```
